### PR TITLE
Fix up font issues

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
-    "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
+    "vue.volar",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
   ]

--- a/index.html
+++ b/index.html
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Whisper&display=swap" rel="stylesheet">
+
     <link rel="icon" href="favicon.svg">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Click N Track</title>
   </head>

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -5,9 +5,9 @@ const githubLink = 'https://github.com/BlakeTheAwesome/clickntrack'
 
 <template>
   <div class="header-bar">
-    <span class="hb-title">Click N Track</span>
+    <span class="hb-title font-comic">Click N Track</span>
     <div class="hb-controls">
-      <span class="hb-author">By MutantSheepdog</span>
+      <span class="hb-author font-signature">By MutantSheepdog</span>
       <slot name="actions"></slot>
       <a :href="githubLink" v-tooltip.bottom="'GitHub'">
         <Button icon="pi pi-github" severity="secondary" text raised rounded aria-label="GitHub" />
@@ -28,12 +28,11 @@ const githubLink = 'https://github.com/BlakeTheAwesome/clickntrack'
 .hb-title {
   font-size: 1.5rem;
   font-weight: bold;
-  font-family: 'Brush Script MT', cursive;
 }
 
 .hb-author {
-  font-size: 1rem;
-  font-family: 'Brush Script MT', cursive;
+  font-size: 1.5rem;
+  font-weight: bold;
   color: #666;
 }
 

--- a/src/components/TrackerStatus.vue
+++ b/src/components/TrackerStatus.vue
@@ -10,7 +10,7 @@ defineProps<{
 </script>
 
 <template>
-  <div class="tracker-status">
+  <div class="tracker-status font-comic">
     <span class="ts-filter">{{ filter }}</span>
     <span class="ts-count">Total: {{ trackerStore.totalCount }}</span>
   </div>
@@ -18,7 +18,6 @@ defineProps<{
 
 <style scoped lang="postcss">
 .tracker-status {
-  font-family: 'Brush Script MT', cursive;
   font-size: 1.5rem;
   display: flex;
   flex-direction: row;

--- a/src/pages/PageItemEditor.vue
+++ b/src/pages/PageItemEditor.vue
@@ -425,7 +425,5 @@ const newKeyword = ref('')
   color: #922;
   font-size: 20px;
   font-weight: bold;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 </style>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,9 @@
 @import './primevue.css';
 
+:root {
+  --default-font: 'Open Sans', sans-serif;
+}
+
 html,
 body,
 main,
@@ -7,4 +11,13 @@ main,
   margin: 0;
   padding: 0;
   height: 100vh;
+  font-family: var(--default-font);
+}
+
+.font-signature {
+  font-family: 'Whisper', cursive;
+}
+
+.font-comic {
+  font-family: 'Bangers', system-ui;
 }


### PR DESCRIPTION
## Why did I make these changes?
<!-- 
  Briefly describe the issue this PR is addressing.
-->
- Addresses issue #12 

## What are the changes?
<!--
  Give a summary of what has changed in this PR, and how those changes were implemented.
-->
In this PR I've added links to the following google fonts
- Whisper: Used for the signature
- Bangers: Used for the title and the tracker total/filter fields
- Open Sans: Default backup text (used in error text in item setup)

### Enhanced Components/Features
<!--
  Add a list of things updated in this PR, and what has been changed.
  Delete if not applicable.
-->
- `index.html`: Added `<link>` fields for google fonts
- `main.css`: Added default font, and `.font-signature`/`.font-comic` classes
- `HeaderBar.vue`/`TrackerStatus.vue`/`PageItemEditor.vue`: Replace old font-families with new classes
- `.vscode/extensions.json`: Removed deprecated `Vue.vscode-typescript-vue-plugin` which is now rolled into `Vue.volar`

## Checklist
- [x] I have run the linter and have no errors - `npm run lint`
- [x] I have run the code formatter - `npm run format`

## Screenshots or example output
<!--
  If you made any visual changes, include screenshot(s) here.
  On MacOS you can create a screenshot using Command+Shift+4, then drag the file here from the desktop.
  Delete if not applicable.
-->

![Screenshot 2024-08-12 160650](https://github.com/user-attachments/assets/7309b870-1c51-4f78-8621-8c0d0c50b988)
