### PR TITLE
Handle errors importing JSON files using PrimeVue toast

### DIFF
--- a/src/plugins/primevue.ts
+++ b/src/plugins/primevue.ts
@@ -2,9 +2,11 @@ import PrimeVue from 'primevue/config'
 import ConfirmationService from 'primevue/confirmationservice'
 import type { App } from 'vue'
 import Tooltip from 'primevue/tooltip'
+import ToastService from 'primevue/toastservice'
 
 export function installPrimeVue(app: App) {
   app.use(PrimeVue)
   app.use(ConfirmationService)
+  app.use(ToastService)
   app.directive('tooltip', Tooltip)
 }


### PR DESCRIPTION
## Why did I make these changes?
<!-- 
  Briefly describe the issue this PR is addressing.
-->
Issue: #1
Errors weren't being handled when importing broken JSON files.

## What are the changes?
<!--
  Give a summary of what has changed in this PR, and how those changes were implemented.
-->
When importing JSON files, errors are now handled and displayed in a PrimeVue toast notification, as well as in the console

### New Components/Features
<!--
  Add a list of things added in this PR, and briefly describe their purpose.
  Delete if not applicable.
-->
- `primevue.ts`: Added `ToastService` when installing PrimeVue components

### Enhanced Components/Features
<!--
  Add a list of things updated in this PR, and what has been changed.
  Delete if not applicable.
-->
- `PageItemEditor.vue`:
  - Added the primevue `Toast` component to the template
  - Updated the `parseJsonFile` function to have a try/catch around the `JSON.Parse`
  - Updated the `presetFileDialog.onChange` to use an error toast when `parseJsonFile` fails

## Checklist
- [x] I have run the linter and have no errors - `npm run lint`
- [x] I have run the code formatter - `npm run format`

## Screenshots or example output
<!--
  If you made any visual changes, include screenshot(s) here.
  On MacOS you can create a screenshot using Command+Shift+4, then drag the file here from the desktop.
  Delete if not applicable.
-->

![Screenshot 2024-08-12 163405](https://github.com/user-attachments/assets/f3ee44df-6c71-44d9-938e-95e31385f1f9)
