### PR TITLE
Add middle-click to mark goals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,12 @@ export default tseslint.config(
         extraFileExtensions: ['.vue'],
       }
     },
+    rules: {
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "vue/attribute-hyphenation": ["error", "never"],
+      "vue/v-on-event-hyphenation": ["error", "never"],
+      "vue/custom-event-name-casing": ["error", "camelCase"],
+    }
   },
   {
     files: ['**/*.mjs'],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false",
-    "lint": "eslint",
+    "lint": "eslint --fix",
     "format": "prettier --write src/",
     "stories": "histoire dev"
   },

--- a/src/components/ClickCountEditor.vue
+++ b/src/components/ClickCountEditor.vue
@@ -102,8 +102,8 @@ const isModified = computed(() => {
 </script>
 
 <template>
-  <DataTable :key="itemKey" :value="mutableItems" @row-reorder="onRowReorder">
-    <Column row-reorder header-style="width: 3rem" />
+  <DataTable :key="itemKey" :value="mutableItems" @rowReorder="onRowReorder">
+    <Column rowReorder headerStyle="width: 3rem" />
     <Column header="Set Default">
       <template #body="slotProps">
         <Button

--- a/src/components/Grid/GridIcon.story.vue
+++ b/src/components/Grid/GridIcon.story.vue
@@ -13,16 +13,16 @@ const item = computed(() => trackerStore.gridItems[0])
 <template>
   <Story>
     <Variant title="Square">
-      <SetLayoutStore item-shape="Square" />
-      <StoryComponent :item="item" :offset-row="false" :filtered="false" />
+      <SetLayoutStore itemShape="Square" />
+      <StoryComponent :item="item" :offsetRow="false" :filtered="false" />
     </Variant>
     <Variant title="Hex">
-      <SetLayoutStore item-shape="Hex" />
-      <StoryComponent :item="item" :offset-row="false" :filtered="false" />
+      <SetLayoutStore itemShape="Hex" />
+      <StoryComponent :item="item" :offsetRow="false" :filtered="false" />
     </Variant>
     <Variant title="Hex Filtered">
-      <SetLayoutStore item-shape="Hex" />
-      <StoryComponent :item="item" :offset-row="false" :filtered="true" />
+      <SetLayoutStore itemShape="Hex" />
+      <StoryComponent :item="item" :offsetRow="false" :filtered="true" />
     </Variant>
   </Story>
 </template>

--- a/src/components/Grid/GridIcon.story.vue
+++ b/src/components/Grid/GridIcon.story.vue
@@ -6,14 +6,16 @@ import { computed } from 'vue'
 const trackerStore = useTrackerStore()
 
 const item = computed(() => trackerStore.gridItems[0])
-
-// Could potentially add more variants here with 'SetLayoutStore' configuring
 </script>
 
 <template>
   <Story>
     <Variant title="Square">
       <SetLayoutStore itemShape="Square" />
+      <StoryComponent :item="item" :offsetRow="false" :filtered="false" />
+    </Variant>
+    <Variant title="Square With Text">
+      <SetLayoutStore itemShape="Square" displayType="Both" textLocation="BR" :textMargin="16" />
       <StoryComponent :item="item" :offsetRow="false" :filtered="false" />
     </Variant>
     <Variant title="Hex">
@@ -23,6 +25,10 @@ const item = computed(() => trackerStore.gridItems[0])
     <Variant title="Hex Filtered">
       <SetLayoutStore itemShape="Hex" />
       <StoryComponent :item="item" :offsetRow="false" :filtered="true" />
+    </Variant>
+    <Variant title="Hex With Text">
+      <SetLayoutStore itemShape="Hex" displayType="Both" textLocation="BR" :textMargin="16" />
+      <StoryComponent :item="item" :offsetRow="false" :filtered="false" />
     </Variant>
   </Story>
 </template>

--- a/src/components/Grid/TrackerGrid.story.vue
+++ b/src/components/Grid/TrackerGrid.story.vue
@@ -8,21 +8,21 @@ const trackerStore = useTrackerStore()
 <template>
   <Story>
     <Variant title="Square Grid">
-      <SetLayoutStore item-shape="Square" />
+      <SetLayoutStore itemShape="Square" />
       <StoryComponent
-        :grid-items="trackerStore.gridItems"
-        :grid-row-len="10"
-        :cell-size="48"
+        :gridItems="trackerStore.gridItems"
+        :gridRowLen="10"
+        :cellSize="48"
         layout="Grid"
         :filter="''"
       />
     </Variant>
     <Variant title="Hex Grid">
-      <SetLayoutStore item-shape="Hex" />
+      <SetLayoutStore itemShape="Hex" />
       <StoryComponent
-        :grid-items="trackerStore.gridItems"
-        :grid-row-len="10"
-        :cell-size="48"
+        :gridItems="trackerStore.gridItems"
+        :gridRowLen="10"
+        :cellSize="48"
         layout="Hex"
         :filter="''"
       />

--- a/src/components/Grid/TrackerGrid.story.vue
+++ b/src/components/Grid/TrackerGrid.story.vue
@@ -9,23 +9,11 @@ const trackerStore = useTrackerStore()
   <Story>
     <Variant title="Square Grid">
       <SetLayoutStore itemShape="Square" />
-      <StoryComponent
-        :gridItems="trackerStore.gridItems"
-        :gridRowLen="10"
-        :cellSize="48"
-        layout="Grid"
-        :filter="''"
-      />
+      <StoryComponent :gridItems="trackerStore.gridItems" :gridRowLen="10" :cellSize="48" layout="Grid" :filter="''" />
     </Variant>
     <Variant title="Hex Grid">
       <SetLayoutStore itemShape="Hex" />
-      <StoryComponent
-        :gridItems="trackerStore.gridItems"
-        :gridRowLen="10"
-        :cellSize="48"
-        layout="Hex"
-        :filter="''"
-      />
+      <StoryComponent :gridItems="trackerStore.gridItems" :gridRowLen="10" :cellSize="48" layout="Hex" :filter="''" />
     </Variant>
   </Story>
 </template>

--- a/src/components/Grid/TrackerGrid.vue
+++ b/src/components/Grid/TrackerGrid.vue
@@ -196,7 +196,7 @@ const margins = computed(() => {
         <template v-for="(item, itemIdx) in row" :key="`${item?.id}-${itemIdx}`">
           <GridIcon
             :item="item"
-            :offset-row="rowIdx % 2 === (offsetOdd ? 1 : 0)"
+            :offsetRow="rowIdx % 2 === (offsetOdd ? 1 : 0)"
             :filtered="filteredIds.has(item?.id)"
           />
         </template>

--- a/src/components/HeaderBar.story.vue
+++ b/src/components/HeaderBar.story.vue
@@ -11,7 +11,7 @@ function localSetupApp({ app }: Vue3StorySetupApi) {
 </script>
 
 <template>
-  <Story :setup-app="localSetupApp">
+  <Story :setupApp="localSetupApp">
     <Variant title="No Actions">
       <StoryComponent />
     </Variant>

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -63,6 +63,38 @@ const itemTextBgColor = computed({
     layoutStore.itemTextBackgroundColor = `#${col}`
   },
 })
+
+const markColor = computed({
+  get: () => layoutStore.markColor.substring(1),
+  set: (col) => {
+    layoutStore.markColor = `#${col}`
+  },
+})
+
+const markShadowColor = computed({
+  get: () => layoutStore.markShadowColor.substring(1),
+  set: (col) => {
+    layoutStore.markShadowColor = `#${col}`
+  },
+})
+
+const showTextSettings = computed(() => {
+  switch (layoutStore.displayType) {
+    case 'Text':
+    case 'Both':
+      return true
+  }
+  return false
+})
+
+const showImageSettings = computed(() => {
+  switch (layoutStore.displayType) {
+    case 'Image':
+    case 'Both':
+      return true
+  }
+  return false
+})
 </script>
 
 <template>
@@ -144,28 +176,15 @@ const itemTextBgColor = computed({
           <div class="sp-item-row">
             Shuffle Available Items: <Checkbox v-model="trackerStore.shuffleItems" class="sp-control" :binary="true" />
           </div>
+          <div class="sp-item-row">Mark Icon: <InputText v-model="layoutStore.markText" class="sp-control" /></div>
           <div class="sp-item-row">
-            <span>Display Type:</span>
-            <Select
-              v-model="layoutStore.displayType"
-              class="sp-control"
-              :options="DisplayTypesMutable"
-              placeholder="Select a shape"
-            />
+            <span>Mark Position:</span>
+            <Select v-model="layoutStore.markLocation" class="sp-control" :options="TextLocationsMutable" />
           </div>
-          <div v-if="layoutStore.displayType !== 'Image'" class="sp-item-row">
-            <span>Text Position:</span>
-            <Select
-              v-model="layoutStore.textLocation"
-              class="sp-control"
-              :options="TextLocationsMutable"
-              placeholder="Select a shape"
-            />
-          </div>
-          <div v-if="layoutStore.displayType !== 'Image'" class="sp-item-row">
-            Text Size:
+          <div class="sp-item-row">
+            Mark Size:
             <InputNumber
-              v-model="layoutStore.textSize"
+              v-model="layoutStore.markSize"
               class="sp-control"
               :min="1"
               :max="100"
@@ -173,33 +192,88 @@ const itemTextBgColor = computed({
               showButtons
             />
           </div>
-          <div v-if="layoutStore.displayType !== 'Text'" class="sp-item-row">
-            Image Margin:
+          <div class="sp-item-row">
+            Mark Margin:
             <InputNumber
-              v-model="layoutStore.imageMargin"
+              v-model="layoutStore.markMargin"
               class="sp-control"
-              :min="-1000"
+              :min="-100"
               :max="1000"
               mode="decimal"
               showButtons
             />
           </div>
-          <div v-if="layoutStore.displayType !== 'Image'" class="sp-item-row">
-            <span>Image Text Color:</span>
-            <ColorPicker v-model="itemTextColor" class="sp-control" />
-          </div>
-          <div v-if="layoutStore.displayType !== 'Image'" class="sp-item-row">
-            <span>Image Text Background Color:</span>
-            <ColorPicker v-model="itemTextBgColor" class="sp-control" />
-          </div>
-          <div v-if="layoutStore.displayType !== 'Image'" class="sp-item-row">
-            <span>Background Opacity:</span>
-            <Slider v-model="layoutStore.itemTextBackgroundOpacityByte" class="sp-control" :min="0" :max="255" />
+          <div class="sp-item-row">
+            <span>Mark Color:</span>
+            <ColorPicker v-model="markColor" class="sp-control" />
           </div>
           <div class="sp-item-row">
-            <span>Highlight Covers Image:</span>
-            <Checkbox v-model="layoutStore.highlightCoversImage" class="sp-control" :binary="true" />
+            <span>Mark Shadow Color:</span>
+            <ColorPicker v-model="markShadowColor" class="sp-control" />
           </div>
+          <div class="sp-item-row">
+            <span>Display Type:</span>
+            <Select v-model="layoutStore.displayType" class="sp-control" :options="DisplayTypesMutable" />
+          </div>
+          <template v-if="showTextSettings">
+            <div class="sp-item-row">
+              <span>Text Position:</span>
+              <Select v-model="layoutStore.textLocation" class="sp-control" :options="TextLocationsMutable" />
+            </div>
+            <div class="sp-item-row">
+              Text Size:
+              <InputNumber
+                v-model="layoutStore.textSize"
+                class="sp-control"
+                :min="1"
+                :max="100"
+                mode="decimal"
+                showButtons
+              />
+            </div>
+            <div class="sp-item-row">
+              Text Margin:
+              <InputNumber
+                v-model="layoutStore.textMargin"
+                class="sp-control"
+                :min="-100"
+                :max="1000"
+                mode="decimal"
+                showButtons
+              />
+            </div>
+          </template>
+          <template v-if="showImageSettings">
+            <div class="sp-item-row">
+              Image Margin:
+              <InputNumber
+                v-model="layoutStore.imageMargin"
+                class="sp-control"
+                :min="-1000"
+                :max="1000"
+                mode="decimal"
+                showButtons
+              />
+            </div>
+            <template v-if="showTextSettings">
+              <div class="sp-item-row">
+                <span>Image Text Color:</span>
+                <ColorPicker v-model="itemTextColor" class="sp-control" />
+              </div>
+              <div class="sp-item-row">
+                <span>Image Text Background Color:</span>
+                <ColorPicker v-model="itemTextBgColor" class="sp-control" />
+              </div>
+              <div class="sp-item-row">
+                <span>Background Opacity:</span>
+                <Slider v-model="layoutStore.itemTextBackgroundOpacityByte" class="sp-control" :min="0" :max="255" />
+              </div>
+            </template>
+            <div class="sp-item-row">
+              <span>Highlight Covers Image:</span>
+              <Checkbox v-model="layoutStore.highlightCoversImage" class="sp-control" :binary="true" />
+            </div>
+          </template>
         </div>
       </TabPanel>
     </TabView>

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -28,7 +28,7 @@ import { useTrackerStore } from '@/stores/trackerStore'
 import ClickCountEditor from './ClickCountEditor.vue'
 
 const emit = defineEmits<{
-  'open-item-set-editor': []
+  openItemSetEditor: []
 }>()
 
 const LayoutsMutable = Layouts as unknown as Layout[]
@@ -40,7 +40,7 @@ const layoutStore = useLayoutStore()
 const trackerStore = useTrackerStore()
 
 function openItemEditor() {
-  emit('open-item-set-editor')
+  emit('openItemSetEditor')
 }
 
 const bgColor = computed({
@@ -87,7 +87,7 @@ const itemTextBgColor = computed({
               :min="1"
               :max="1000"
               mode="decimal"
-              show-buttons
+              showButtons
             />
           </div>
           <div class="sp-item-row">
@@ -107,7 +107,7 @@ const itemTextBgColor = computed({
               :min="1"
               :max="1000"
               mode="decimal"
-              show-buttons
+              showButtons
             />
           </div>
         </div>
@@ -137,7 +137,7 @@ const itemTextBgColor = computed({
               :min="1"
               :max="10000"
               mode="decimal"
-              show-buttons
+              showButtons
             />
           </div>
           <div class="sp-item-row">Seed: <InputText v-model="trackerStore.seed" class="sp-control" /></div>
@@ -170,7 +170,7 @@ const itemTextBgColor = computed({
               :min="1"
               :max="100"
               mode="decimal"
-              show-buttons
+              showButtons
             />
           </div>
           <div v-if="layoutStore.displayType !== 'Text'" class="sp-item-row">
@@ -181,7 +181,7 @@ const itemTextBgColor = computed({
               :min="-1000"
               :max="1000"
               mode="decimal"
-              show-buttons
+              showButtons
             />
           </div>
           <div v-if="layoutStore.displayType !== 'Image'" class="sp-item-row">

--- a/src/pages/PageItemEditor.vue
+++ b/src/pages/PageItemEditor.vue
@@ -35,8 +35,8 @@ function exportJson(items: readonly TrackerItem[]) {
   <PageItemEditorLayout
     v-model:grid-items="trackerStore.allGridItems"
     :presets="presets"
-    @init-tracker="trackerStore.initTracker($event)"
-    @return-home="router.push({ name: 'tracker' })"
-    @export-items="exportJson"
+    @initTracker="trackerStore.initTracker($event)"
+    @returnHome="router.push({ name: 'tracker' })"
+    @exportItems="exportJson"
   />
 </template>

--- a/src/pages/PageItemEditorLayout.vue
+++ b/src/pages/PageItemEditorLayout.vue
@@ -25,9 +25,9 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:gridItems': [items: TrackerItem[]]
-  'init-tracker': [items: readonly TrackerItem[]]
-  'export-items': [items: readonly TrackerItem[]]
-  'return-home': []
+  initTracker: [items: readonly TrackerItem[]]
+  exportItems: [items: readonly TrackerItem[]]
+  returnHome: []
 }>()
 
 const toast = useToast()
@@ -58,7 +58,7 @@ function loadPreset(preset: readonly TrackerItem[]) {
     reject: () => {},
     accept: () => {
       editingRows.value = []
-      emit('init-tracker', preset)
+      emit('initTracker', preset)
     },
   })
 }
@@ -223,7 +223,7 @@ const onRowEditSave = (event: DataTableRowEditSaveEvent) => {
 }
 
 function exportJson() {
-  emit('export-items', mutableItems.value)
+  emit('exportItems', mutableItems.value)
 }
 
 function updateIds() {
@@ -233,7 +233,7 @@ function updateIds() {
 }
 
 function returnToHome() {
-  const callback = () => emit('return-home')
+  const callback = () => emit('returnHome')
 
   if (!isModified.value && editingRows.value.length === 0) {
     callback()
@@ -302,13 +302,13 @@ const newKeyword = ref('')
         :value="mutableItems"
         paginator
         :rows="50"
-        :rows-per-page-options="[5, 10, 20, 50, 100, 200, 500, 1000, 5000]"
-        edit-mode="row"
-        @row-reorder="onRowReorder"
-        @row-edit-save="onRowEditSave"
+        :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 500, 1000, 5000]"
+        editMode="row"
+        @rowReorder="onRowReorder"
+        @rowEditSave="onRowEditSave"
       >
-        <Column row-reorder header-style="width: 3rem" />
-        <Column header="Id" field="id" header-style="width: 3rem" />
+        <Column rowReorder headerStyle="width: 3rem" />
+        <Column header="Id" field="id" headerStyle="width: 3rem" />
         <Column header="Display Name" field="displayName">
           <template #editor="{ data, field }">
             <InputText v-model="data[field]" size="small" />
@@ -345,7 +345,7 @@ const newKeyword = ref('')
               display="chip"
               :options="availableKeywords"
               placeholder="Keywords"
-              scroll-height="500px"
+              scrollHeight="500px"
             >
               <template #header>
                 <div class="pie-new-keyword-row">
@@ -365,8 +365,8 @@ const newKeyword = ref('')
             </div>
           </template>
         </Column>
-        <Column :row-editor="true" style="width: 10%; min-width: 8rem" body-style="text-align:center" />
-        <Column header-style="width: 3rem">
+        <Column :rowEditor="true" style="width: 10%; min-width: 8rem" bodyStyle="text-align:center" />
+        <Column headerStyle="width: 3rem">
           <template #body="slotProps">
             <Button icon="pi pi-trash" severity="danger" text aria-label="Clear" @click="deleteItem(slotProps.index)" />
           </template>

--- a/src/pages/PageTracker.vue
+++ b/src/pages/PageTracker.vue
@@ -16,8 +16,8 @@ function openItemEditor() {
 
 <template>
   <PageTrackerLayout
-    :grid-items="trackerStore.gridItems"
-    @open-item-editor="openItemEditor"
-    @clear-tracker="trackerStore.clearTracker"
+    :gridItems="trackerStore.gridItems"
+    @openItemEditor="openItemEditor"
+    @clearTracker="trackerStore.clearTracker"
   />
 </template>

--- a/src/pages/PageTrackerLayout.story.vue
+++ b/src/pages/PageTrackerLayout.story.vue
@@ -9,6 +9,6 @@ const trackerStore = useTrackerStore()
 
 <template>
   <Story>
-    <StoryComponent :grid-items="trackerStore.gridItems" v-on="logEmits(StoryComponent)" />
+    <StoryComponent :gridItems="trackerStore.gridItems" v-on="logEmits(StoryComponent)" />
   </Story>
 </template>

--- a/src/pages/PageTrackerLayout.vue
+++ b/src/pages/PageTrackerLayout.vue
@@ -19,8 +19,8 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'open-item-editor': []
-  'clear-tracker': []
+  openItemEditor: []
+  clearTracker: []
 }>()
 
 const layoutStore = useLayoutStore()
@@ -54,7 +54,7 @@ const contentPadding = computed(() => {
             raised
             rounded
             aria-label="Clear"
-            @click="emit('clear-tracker')"
+            @click="emit('clearTracker')"
           />
           <Button
             v-tooltip.bottom="'Settings'"
@@ -74,17 +74,17 @@ const contentPadding = computed(() => {
         <SplitterPanel :size="75" class="pt-content" tabindex="0" @keydown="onKeydown">
           <div class="pt-grid-area">
             <TrackerGrid
-              :grid-items="props.gridItems"
-              :grid-row-len="gridRowLength"
-              :cell-size="cellSize"
+              :gridItems="props.gridItems"
+              :gridRowLen="gridRowLength"
+              :cellSize="cellSize"
               :layout="layout"
               :filter="filter"
             />
             <TrackerStatus :filter="filter" />
           </div>
         </SplitterPanel>
-        <SplitterPanel v-if="showSettings" :size="25" :min-size="25">
-          <SettingsPanel class="pt-settings" @open-item-set-editor="emit('open-item-editor')" />
+        <SplitterPanel v-if="showSettings" :size="25" :minSize="25">
+          <SettingsPanel class="pt-settings" @openItemSetEditor="emit('openItemEditor')" />
         </SplitterPanel>
       </Splitter>
     </div>

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -9,21 +9,29 @@ export const DisplayTypes = ['Image', 'Text', 'Both'] as const
 export type DisplayType = (typeof DisplayTypes)[number]
 export const TextLocations = ['TL', 'TC', 'TR', 'CL', 'CC', 'CR', 'BL', 'BC', 'BR'] as const
 export type TextLocation = (typeof TextLocations)[number]
+export type MarkLocation = TextLocation
 
 export const useLayoutStore = defineStore('layout', () => {
   const bgColor = ref('#FFFFFF')
   const itemTextColor = ref('#ffffff')
+  const markColor = ref('#ffffff')
+  const markShadowColor = ref('#000000')
+  const markText = ref('★')
   const itemTextBackgroundColor = ref('#000000')
   const itemTextBackgroundOpacityByte = ref(200)
   const cellSize = ref(48)
   const layout = ref<Layout>('Grid')
   const itemShape = ref<ItemShape>('Square')
   const displayType = ref<DisplayType>('Image')
+  const markLocation = ref<MarkLocation>('TL')
   const textLocation = ref<TextLocation>('CC')
   const gridRowLength = ref(10)
   const imageMargin = ref(0)
+  const textMargin = ref(0)
+  const markMargin = ref(0)
   const showTooltips = ref(true)
   const textSize = ref(16)
+  const markSize = ref(20)
   const highlightCoversImage = ref(false)
 
   return {
@@ -39,7 +47,14 @@ export const useLayoutStore = defineStore('layout', () => {
     showTooltips,
     highlightCoversImage,
     textLocation,
+    textMargin,
     imageMargin,
     textSize,
+    markLocation,
+    markText,
+    markSize,
+    markColor,
+    markShadowColor,
+    markMargin,
   }
 })

--- a/src/stores/trackerStore.ts
+++ b/src/stores/trackerStore.ts
@@ -5,7 +5,7 @@ import type { TrackerItem } from '@/types/trackerItem'
 import { shuffle } from '@/scripts/randomUtils'
 import pokemonList from '@/assets/pokemon-list.json'
 
-type ItemState = { clickCount: number }
+type ItemState = { clickCount: number; marked: boolean }
 type IdState = Record<number, ItemState>
 
 const defaultColours: ClickCountEntry[] = [
@@ -15,6 +15,13 @@ const defaultColours: ClickCountEntry[] = [
   { id: 2, color: '#FF6633', countsTowardsTotal: true },
   { id: 3, color: '#66B399', countsTowardsTotal: true },
 ]
+
+function newItem(): ItemState {
+  return {
+    clickCount: 0,
+    marked: false,
+  }
+}
 
 export const useTrackerStore = defineStore('tracker', () => {
   const idState = ref<IdState>({})
@@ -49,31 +56,41 @@ export const useTrackerStore = defineStore('tracker', () => {
     return count
   })
 
+  function getOrCreateItem(id: number): ItemState {
+    let entry = idState.value[id]
+    if (!entry) {
+      entry = reactive(newItem())
+      idState.value[id] = entry
+    }
+    return entry
+  }
+
   function getClickInfo(id: number) {
-    const count = idState.value[id]?.clickCount ?? 0
+    const state = idState.value[id]
+    const count = state?.clickCount ?? 0
     const colour = clickCountMap.value.get(count)?.color ?? '#000000'
+    const marked = state?.marked
+
     return {
       count,
       colour,
+      marked,
     }
   }
 
   function incrementClickCount(id: number) {
-    let entry = idState.value[id]
-    if (!entry) {
-      entry = reactive({ clickCount: 0 })
-      idState.value[id] = entry
-    }
+    const entry = getOrCreateItem(id)
     entry.clickCount = Math.min(entry.clickCount + 1, maxClickCount.value)
   }
 
   function decrementClickCount(id: number) {
-    let entry = idState.value[id]
-    if (!entry) {
-      entry = reactive({ clickCount: 0 })
-      idState.value[id] = entry
-    }
+    const entry = getOrCreateItem(id)
     entry.clickCount = Math.max(entry.clickCount - 1, minClickCount.value)
+  }
+
+  function toggleMarked(id: number) {
+    const entry = getOrCreateItem(id)
+    entry.marked = !entry.marked
   }
 
   function initTracker(items: readonly TrackerItem[]) {
@@ -84,7 +101,7 @@ export const useTrackerStore = defineStore('tracker', () => {
   function clearTracker() {
     idState.value = {}
     for (const item of gridItems.value) {
-      idState.value[item.id] = reactive({ clickCount: 0 })
+      idState.value[item.id] = reactive(newItem())
     }
   }
 
@@ -92,6 +109,7 @@ export const useTrackerStore = defineStore('tracker', () => {
     getClickInfo,
     incrementClickCount,
     decrementClickCount,
+    toggleMarked,
     idState,
     numItems,
     seed,


### PR DESCRIPTION
## Why did I make these changes?
<!-- 
  Briefly describe the issue this PR is addressing.
-->
Issue: #4 
It is useful to be able to mark target goals separately to their completion status.

## What are the changes?
<!--
  Give a summary of what has changed in this PR, and how those changes were implemented.
-->
You can now middle-click on goals to add a mark (defaults to a star in the top left) to any goal.

### Enhanced Components/Features
<!--
  Add a list of things updated in this PR, and what has been changed.
  Delete if not applicable.
-->
- `eslint.config.mjs`:
  - Disabled `@typescript-eslint/restrict-template-expressions` which restricted which variables could be stringified using this syntax: `${x}` 
  - Changed vue prop and events to be camelCase instead of kebab-case which fixed the `SetLayoutStore` component
- `trackerStore.ts`: `ItemState` now includes a `marked: boolean` field
- `layoutStore.ts`: New settings: `markText`, `markLocation`, `markSize`, `markMagin`, `markColor`, `markShadowColor`, `textMargin`
- `SettingsPanel.vue`: Added new settings
- `GridIcon`: Added mark icon and middle-click handler

## Checklist
- [x] I have run the linter and have no errors - `npm run lint`
- [x] I have run the code formatter - `npm run format`

## Screenshots or example output
<!--
  If you made any visual changes, include screenshot(s) here.
  On MacOS you can create a screenshot using Command+Shift+4, then drag the file here from the desktop.
  Delete if not applicable.
-->

![Screenshot 2024-08-16 172019](https://github.com/user-attachments/assets/c54d8b09-a019-4133-b44d-dcf6e154a15b)
