### PR TITLE
Make keyword prefix customisable

### DIFF
--- a/src/components/Grid/TrackerGrid.vue
+++ b/src/components/Grid/TrackerGrid.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   gridRowLen: number
   cellSize: number
   filter?: string
+  keywordPrefix: string
   layout: Layout
 }>()
 
@@ -174,7 +175,7 @@ const filteredIds = computed(() => {
   if (!props.filter) {
     return new Set()
   }
-  return getIdsToFilterOut(props.filter, props.gridItems)
+  return getIdsToFilterOut(props.filter, props.keywordPrefix, props.gridItems)
 })
 
 const cellSizeStr = computed(() => `${props.cellSize}px`)

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -142,6 +142,10 @@ const showImageSettings = computed(() => {
               showButtons
             />
           </div>
+          <div class="sp-item-row">
+            <span>Keyword Prefix (default ":"):</span>
+            <InputText v-model="layoutStore.keywordPrefix" class="sp-control" placeholder="<none>" maxlength="1" />
+          </div>
         </div>
       </TabPanel>
       <TabPanel header="Display">

--- a/src/pages/PageTrackerLayout.vue
+++ b/src/pages/PageTrackerLayout.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
 }>()
 
 const layoutStore = useLayoutStore()
-const { cellSize, layout, gridRowLength } = storeToRefs(layoutStore)
+const { cellSize, layout, gridRowLength, keywordPrefix } = storeToRefs(layoutStore)
 
 const { filter, onKeydown } = useKeyboardFilter()
 
@@ -79,6 +79,7 @@ const contentPadding = computed(() => {
               :cellSize="cellSize"
               :layout="layout"
               :filter="filter"
+              :keywordPrefix="keywordPrefix"
             />
             <TrackerStatus :filter="filter" />
           </div>

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -33,6 +33,7 @@ export const useLayoutStore = defineStore('layout', () => {
   const textSize = ref(16)
   const markSize = ref(20)
   const highlightCoversImage = ref(false)
+  const keywordPrefix = ref(':')
 
   return {
     bgColor,
@@ -56,5 +57,6 @@ export const useLayoutStore = defineStore('layout', () => {
     markColor,
     markShadowColor,
     markMargin,
+    keywordPrefix,
   }
 })


### PR DESCRIPTION
## Why did I make these changes?
<!-- 
  Briefly describe the issue this PR is addressing.
-->
Issue #7
Filtering by keyword required the user to prefix the keyword with `:`. This is now customisable.

## What are the changes?
<!--
  Give a summary of what has changed in this PR, and how those changes were implemented.
-->
- `filterUtils.ts`:
  - `itemMatchesFilters()` Now handles the case where `namesToMatch` and `kewordsToMatch` are both passed in, returning true if either check passes
  - Updated `getIdsToFilterOut()` to take `keywordPrefix` as a function argument instead of hard-coding `:`
- `layoutStore.ts`:
  - Added `keywordPrefix` (default `:`)
- `SettingsPanel`:
  - Added setting which modifies the field in layoutStore
- `TrackerGrid`:
  - Added `keywordPrefix` prop which is passed to `getIdsToFilterOut()`
- `PageTrackerLayout`:
  - Passes the `layoutStore.keywordPrefix` through to `TrackerGrid`

## Checklist
- [x] I have run the linter and have no errors - `npm run lint`
- [x] I have run the code formatter - `npm run format`

## Screenshots or example output
<!--
  If you made any visual changes, include screenshot(s) here.
  On MacOS you can create a screenshot using Command+Shift+4, then drag the file here from the desktop.
  Delete if not applicable.
-->

Prefix set to `+` (Matches ground/grass but not grimer)

![Screenshot 2024-08-25 194408](https://github.com/user-attachments/assets/9eb02cc1-ca31-4fd4-9797-7ddda0c5045c)

No prefix (Matches ground/grass as well as grimer)

![Screenshot 2024-08-25 194337](https://github.com/user-attachments/assets/bf838bae-ec1c-4c38-9da4-c448e442cb7d)
