### PR TITLE
Add github workflow action to build and deploy when main is updated

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Why did I make these changes?
<!-- 
  Briefly describe the issue this PR is addressing.
-->
If the page is hosted somewhere, it is much easier for people to find, use and share.
This resolves #3

## What are the changes?
<!--
  Give a summary of what has changed in this PR, and how those changes were implemented.
-->
Added a github action to build and deploy the page to github pages. Should now be accessible at https://blaketheawesome.github.io/clickntrack/
